### PR TITLE
Conditional clear event message filter

### DIFF
--- a/MessageTransports/RockyBus.Azure.ServiceBus/ReceivingEndpoint.cs
+++ b/MessageTransports/RockyBus.Azure.ServiceBus/ReceivingEndpoint.cs
@@ -159,7 +159,7 @@ namespace RockyBus.Azure.ServiceBus
         async Task<bool> IsDelta(IEnumerable<Rule> eventMessageTypes)
         {
             var existingMessageRules = await GetExistingRules();
-            // Existing message rules has command message filter, so need to remove before comparing
+            // Existing message rules have command message filter, so need to remove before comparing
             var existingMessageRulesCount = existingMessageRules.Any() ? existingMessageRules.Count() - 1 : 0;
             return eventMessageTypes.Count() != existingMessageRulesCount;
         }


### PR DESCRIPTION
Subscribers are losing messages on Startup due to deleting event message filters. This change will only delete event message filters if the number of rules are less than the existing number of rules.